### PR TITLE
Prepare worker module for CF import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# RU Mobile Redirect Worker
+
+This repository provides a small utility for Cloudflare Workers that redirects
+mobile visitors from Russia to a fallback URL.
+
+## Usage
+
+Install as an npm dependency or copy `worker.js` into your Worker project.
+
+```bash
+npm install <path-to-this-repo>
+```
+
+Import the handler and use it in your Cloudflare Worker:
+
+```javascript
+import { redirectRuMobile } from 'ru-mobile-redirect/worker';
+
+export default {
+  fetch: redirectRuMobile
+};
+```
+
+The redirect destination is defined through the `FALLBACK_URL` environment
+variable.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ru-mobile-redirect",
+  "version": "0.1.0",
+  "description": "Redirect Russian mobile traffic in Cloudflare Workers",
+  "type": "module",
+  "main": "worker.js",
+  "exports": {
+    "./worker": "./worker.js"
+  },
+  "keywords": ["cloudflare", "worker", "redirect"],
+  "author": "",
+  "license": "MIT"
+}

--- a/worker.js
+++ b/worker.js
@@ -3,8 +3,14 @@
 const BOT_UA = /\b(googlebot|bingbot|yandex(bot|images)|duckduckbot|baiduspider|slurp|mail\.ru_bot|applebot|facebookexternalhit|twitterbot|discordbot|telegrambot)\b/i;
 const MOBILE_UA = /\b(android|iphone|ipod|windows phone|opera mini|opera mobi|blackberry|bb10|silk\/|kindle|webos|iemobile)\b/i;
 
-export default {
-  async fetch(request, env) {
+/**
+ * Handler for Cloudflare Workers to redirect RU mobile traffic.
+ *
+ * @param {Request} request Incoming request object
+ * @param {Record<string, string>} env Environment bindings
+ * @returns {Promise<Response>}
+ */
+export async function redirectRuMobile(request, env) {
     const url = new URL(request.url);
 
     /* 1. страна: RU */
@@ -43,5 +49,8 @@ export default {
         'X-Edge-Redirect': 'ru-mobile'
       }
     });
-  }
+}
+
+export default {
+  fetch: redirectRuMobile
 };


### PR DESCRIPTION
## Summary
- export handler function so it can be consumed by other workers
- add package.json declaring module entry
- document usage in README
- ignore node_modules

## Testing
- `node -e "import('./worker.js').then(m=>console.log('export',typeof m.redirectRuMobile));"`

------
https://chatgpt.com/codex/tasks/task_e_687c92ace0e483259c8eac5dfb666f1e